### PR TITLE
Another tweak to find isfinite on Apple M1

### DIFF
--- a/configure
+++ b/configure
@@ -19731,7 +19731,7 @@ printf "%s\n" "$as_me: Checking for proper name for isfinite()." >&6;}
   ac_name_of_isfinite=
 
   if test -z "$ac_name_of_isfinite" ; then
-    for fname in isfinite finite _finite ; do
+    for fname in __builtin_isfinite isfinite finite _finite ; do
       as_ac_Symbol=`printf "%s\n" "ac_cv_have_decl_$fname" | $as_tr_sh`
 ac_fn_check_decl "$LINENO" "$fname" "$as_ac_Symbol" "
   #ifdef HAVE_CMATH
@@ -19788,7 +19788,7 @@ printf "%s\n" "$as_me: Checking for proper name for isnan()." >&6;}
   ac_name_of_isnan=
 
   if test -z "$ac_name_of_isnan" ; then
-    for fname in isnan _isnan isnand _isnand nan _nan ; do
+    for fname in __builtin_isnan isnan _isnan isnand _isnand nan _nan ; do
       as_ac_Symbol=`printf "%s\n" "ac_cv_have_decl_$fname" | $as_tr_sh`
 ac_fn_check_decl "$LINENO" "$fname" "$as_ac_Symbol" "
   #ifdef HAVE_CMATH

--- a/m4/ac_dylp_find_fp_funcs.m4
+++ b/m4/ac_dylp_find_fp_funcs.m4
@@ -20,7 +20,7 @@ AC_DEFUN([AC_DYLP_FIND_ISFINITE],
   ac_name_of_isfinite=
 
   if test -z "$ac_name_of_isfinite" ; then
-    for fname in isfinite finite _finite ; do
+    for fname in __builtin_isfinite isfinite finite _finite ; do
       AC_CHECK_DECL([$fname],[ac_name_of_isfinite=$fname],,AC_COIN_MATH_HDRS)
       if test -n "$ac_name_of_isfinite" ; then
         break
@@ -55,7 +55,7 @@ AC_DEFUN([AC_DYLP_FIND_ISNAN],
   ac_name_of_isnan=
 
   if test -z "$ac_name_of_isnan" ; then
-    for fname in isnan _isnan isnand _isnand nan _nan ; do
+    for fname in __builtin_isnan isnan _isnan isnand _isnand nan _nan ; do
       AC_CHECK_DECL([$fname],[ac_name_of_isnan=$fname],,AC_COIN_MATH_HDRS)
       if test -n "$ac_name_of_isnan" ; then
         break


### PR DESCRIPTION
Apparently __builtin__ originated with GCC and has propagated to other compilers. This mod works on Fedora with GCC. Let's see if it works on Apple M1.