### PR TITLE
Update CI for outdated actions, build issues, add macos-14, remove mingw32

### DIFF
--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -22,32 +22,33 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04, ubuntu-20.04]
+        os: [ubuntu-20.04, ubuntu-22.04]
         build_static: [true, false]
         flags: [ADD_CXXFLAGS=-fvisibility=hidden]
         download_requirements: [sudo apt install -y -qq gfortran liblapack-dev libmetis-dev libnauty2-dev]
         include:
-          - os: macos-10.15
+          - os: macos-13
             build_static: false
-            flags: CC=clang OSX=10.15
+            flags: CC=clang OSX=13
             download_requirements: brew install metis bash
-          - os: macos-10.15
+          - os: macos-13
             build_static: false
-            flags: CC=gcc-9 CXX=g++-9 OSX=10.15
+            flags: CC=gcc-13 CXX=g++-13 OSX=13 ADD_CXXFLAGS=-Wl,-ld_classic
             download_requirements: brew install metis bash
-          - os: macos-10.15
+          - os: macos-14
+            arch: arm64
             build_static: false
-            flags: CC=gcc-10 CXX=g++-10 OSX=10.15
+            flags: CC=gcc-13 CXX=g++-13 OSX=14 ADD_CXXFLAGS=-Wl,-ld_classic
             download_requirements: brew install metis bash
     steps:
       - name: Checkout source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           path: ${{ github.event.repository.name }}
       - name: Install required packages from package manager
         run: ${{ matrix.download_requirements }}
       - name: Checkout coinbrew
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: coin-or/coinbrew
           path: coinbrew
@@ -74,11 +75,11 @@ jobs:
           cp ${{ github.event.repository.name }}/LICENSE dist/
           tar -czvf release.tar.gz -C dist .
       - name: Checkout package name generation script
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: coin-or-tools/platform-analysis-tools
           path: tools
-          ref: 0.0.1
+          ref: 0.0.2
       - name: Retrieve platform info
         run: |
           python3 -m venv venv
@@ -88,10 +89,9 @@ jobs:
           platform_str=`python3 tools/hsf_get_platform.py -b $buildtype`
           echo "platform_string=${platform_str}" >> $GITHUB_ENV
       - name: Upload Artifact
-        if: ${{ github.event_name == 'pull_request'}}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
-          name: ${{ github.event.repository.name }}-${{ github.head_ref }}-${{ env.platform_string }}.tar.gz
+          name: ${{ github.event.repository.name }}-${{ env.platform_string }}.tar.gz
           path: release.tar.gz
           if-no-files-found: error
       - name: Upload package to release

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -26,29 +26,27 @@ jobs:
         include: [
           { os: windows-2019, arch: x86_64, msystem: mingw64, debug: true, suffix: "-dbg" },
           { os: windows-2019, arch: x86_64, msystem: mingw64, debug: false, suffix: "" },
-          { os: windows-2019, arch: i686, msystem: mingw32, debug: true, suffix: "-dbg" },
-          { os: windows-2019, arch: i686, msystem: mingw32, debug: false, suffix: "" },
           { os: windows-2019, arch: msvc, msystem: mingw64, debug: false, suffix: "-md" },
           { os: windows-2022, arch: msvc, msystem: mingw64, debug: false, suffix: "-md" },
         ]
     steps:
       - name: Checkout source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           path: ${{ github.event.repository.name }}
       - name: Checkout coinbrew
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           repository: coin-or/coinbrew
           path: coinbrew
       - name: Set up msvc
-        uses: ilammy/msvc-dev-cmd@v1
         if: ${{ matrix.arch == 'msvc' }}
+        uses: ilammy/msvc-dev-cmd@v1
       - name: Set correct host flag and install requirements
+        if: ${{ matrix.arch != 'msvc' }}
         run: |
           echo "host_flag=--host=${{ matrix.arch }}-w64-mingw32" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           C:\msys64\usr\bin\pacman -S mingw-w64-${{ matrix.arch }}-lapack mingw-w64-${{ matrix.arch }}-winpthreads-git mingw-w64-${{ matrix.arch }}-readline mingw-w64-${{ matrix.arch }}-suitesparse mingw-w64-${{ matrix.arch }}-metis --noconfirm
-        if: ${{ matrix.arch != 'msvc' }}
       - name: Set up msys with ${{ matrix.msystem }}
         uses: msys2/setup-msys2@v2
         with:
@@ -75,7 +73,7 @@ jobs:
           cp ${{ github.event.repository.name }}/LICENSE dist/
         shell: msys2 {0}
       - name: Upload failed build directory
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: ${{ matrix.os}}-{{ matrix.arch }}-debug=${{ matrix.debug }}-failedbuild
@@ -92,10 +90,9 @@ jobs:
         shell: msys2 {0}
         if: ${{ matrix.arch != 'msvc' }}
       - name: Upload artifact
-        if: ${{ github.event_name == 'pull_request'}}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
-          name: ${{ github.event.repository.name }}-${{ github.head_ref }}-${{ env.package_suffix }}
+          name: ${{ github.event.repository.name }}-${{ env.package_suffix }}
           path: dist
           if-no-files-found: error
       - name: Zip up dist contents for release


### PR DESCRIPTION
These changes perform general maintenance on the GitHub Actions workflows for builds for Linux and Windows.
Notably:
- Update outdated build actions (e.g. checkout@v2 -> checkout@v4, etc.)
- Always upload artifact
- Windows: Remove mingw32 builds (32-bit is being removed)
- Linux: Update to recent Ubuntu
- Linux: Update to macos 13 and 14 arm64, and fix gcc build issues
- Linux: Use latest package name generation for macos
- Note: Without Windows MSVS steps

See also https://github.com/coin-or/COIN-OR-OptimizationSuite/issues/25
